### PR TITLE
Convert plist webloc file (binary, JSON...) into XML format.

### DIFF
--- a/webloc2url.sh
+++ b/webloc2url.sh
@@ -78,7 +78,7 @@ while read p; do
 	## see: http://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats
 	dot_clean -m $DIR
 
-	LINK=`cat "$p" | grep "string" | sed "s/<string>//" | sed "s/<\/string>//" | sed "s/	//"`
+	LINK=`plutil -convert xml1 -o - "$p" | grep "string" | sed "s/<string>//" | sed "s/<\/string>//" | sed "s/	//"`
 	## NOTE: last sed contains a TAB caracter
 	echo " - Link is: $LINK"
 


### PR DESCRIPTION
Not all weblog files have XML format. As a matter of fact, Safari in OS X 10.10 and 10.11 creates binary plist files. Luckily OS X has command line tool – plutil – that can be used to convert between various formats of plist files.
